### PR TITLE
Update post-dominance algorithm

### DIFF
--- a/src/frontend/cfg/graph.ts
+++ b/src/frontend/cfg/graph.ts
@@ -51,10 +51,10 @@ export default class Graph<T> {
   }
 
   get root(): GraphNode<T> {
-    // todo: think of a definition of the root node
-    // given graph G(N), root(G) = n in N && getImmPredecessors(n) = []
-    // or given graph G(N), root(G) = n in N && n.offset = 0
-    return this.nodes[0];
+    return (
+      this.nodes.find((n) => this.getImmPredecessors(n).length === 0) ||
+      this.nodes[0]
+    );
   }
 
   get latchingNodes(): Array<GraphNode<T>> {

--- a/src/frontend/cfg/test/graph-utils.spec.ts
+++ b/src/frontend/cfg/test/graph-utils.spec.ts
@@ -1,6 +1,13 @@
 import Graph from '../graph';
 import * as graphUtils from '../graph-utils';
-import { complexGraph, endlessLoop } from './graph.sample';
+import {
+  complexGraph,
+  endlessLoop,
+  graph1,
+  graph2,
+  graph3,
+  graph4,
+} from './graph.sample';
 import { IBasicBlock } from 'common/interfaces';
 import { eBasicBlockType } from 'common/enums';
 
@@ -132,30 +139,105 @@ describe('Graph utils', () => {
     expect(pdom).toBeArrayOfSize(rpoGraph.nodes.length);
 
     expect(pdom[0]).toEqual([
-      rpoGraph.nodes[0], // B1
-      rpoGraph.nodes[4], // B5
-      rpoGraph.nodes[5], // B6
-      rpoGraph.nodes[10], // B7
-      rpoGraph.nodes[13], // B10
-      rpoGraph.nodes[14], // B11
+      1, // B1
+      5, // B5
+      6, // B6
+      7, // B7
+      10, // B10
+      11, // B11
     ]);
-    expect(pdom[14]).toEqual([rpoGraph.nodes[14]]); // B11
+    expect(pdom[14]).toEqual([11]); // B11
 
     const pd = graphUtils.findPDom(endlessLoop());
-
     expect(pd).toEqual([[1, 2, 4, 5], [2, 4, 5], [3, 4, 5], [4, 5], [5]]);
   });
 
-  it('should transpose a given graph', () => {
-    const transposed = graphUtils.transpose(endlessLoop());
-    expect(transposed.nodes).toEqual([5, 4, 3, 2, 1]);
-    expect(transposed.edges).toEqual([
-      { from: 1, to: 5 },
-      { from: 5, to: 4 },
-      { from: 4, to: 3 },
-      { from: 3, to: 2 },
-      { from: 4, to: 2 },
-      { from: 2, to: 1 },
+  it('should produce immediate post-dominators list', () => {
+    const g1 = graph1();
+    const idom1 = graphUtils.findIPDom(g1);
+    expect(idom1).toEqual([2, 5, 4, 1, undefined]);
+
+    const g2 = graph2();
+    const idom2 = graphUtils.findIPDom(g2);
+    expect(idom2).toEqual([2, 3, undefined]);
+
+    const g3 = graph3();
+    const idom3 = graphUtils.findIPDom(g3);
+    expect(idom3).toEqual([5, 5, 5, 3, undefined]);
+  });
+
+  it('should reverse a given graph', () => {
+    const g = graph3();
+    const reversed = graphUtils.reverse(g);
+    expect(reversed.nodes).toEqual(g.nodes);
+    g.edges.forEach((edge, i) => {
+      expect(edge.from).toBe(reversed.edges[i].to);
+      expect(edge.to).toBe(reversed.edges[i].from);
+    });
+    expect(reversed.root).toBe(g.nodes[4]);
+  });
+
+  it('should calculate post-dominators using simple-fast algorithm', () => {
+    const g = graph4();
+    const dom = graphUtils.findIDom(g);
+    expect(dom).toEqual([
+      undefined,
+      0,
+      1,
+      2,
+      2,
+      4,
+      5,
+      5,
+      3,
+      8,
+      9,
+      9,
+      11,
+      12,
+      12,
+      2,
+    ]);
+
+    const reversed = graphUtils.reverse(g);
+    const idom = graphUtils.findIDom(reversed);
+    expect(idom).toEqual([
+      1,
+      2,
+      15,
+      8,
+      5,
+      15,
+      15,
+      1,
+      9,
+      15,
+      15,
+      12,
+      15,
+      15,
+      8,
+      undefined,
+    ]);
+
+    const ipdom = graphUtils.findIPDom(g);
+    expect(ipdom).toEqual([
+      1,
+      2,
+      15,
+      8,
+      5,
+      15,
+      15,
+      1,
+      9,
+      15,
+      15,
+      12,
+      15,
+      15,
+      8,
+      undefined,
     ]);
   });
 });

--- a/src/frontend/cfg/test/graph.sample.ts
+++ b/src/frontend/cfg/test/graph.sample.ts
@@ -112,3 +112,123 @@ export function ifNestedInLoop(): Graph<number> {
       [7]<---
   */
 }
+
+export function graph1(): Graph<number> {
+  const graph = new Graph<number>();
+
+  const n1 = 1;
+  const n2 = 2;
+  const n3 = 3;
+  const n4 = 4;
+  const n5 = 5;
+
+  graph.addNode(n1, n2, n3, n4, n5);
+
+  graph.addEdge(n1, n2);
+  graph.addEdge(n1, n3);
+  graph.addEdge(n2, n5);
+  graph.addEdge(n2, n3);
+  graph.addEdge(n3, n4);
+  graph.addEdge(n4, n1);
+
+  return graph;
+}
+
+export function graph2(): Graph<number> {
+  const graph = new Graph<number>();
+
+  const n1 = 1;
+  const n2 = 2;
+  const n3 = 3;
+
+  graph.addNode(n1, n2, n3);
+
+  graph.addEdge(n1, n2);
+  graph.addEdge(n2, n3);
+  graph.addEdge(n3, n1);
+
+  return graph;
+}
+
+export function graph3(): Graph<number> {
+  const graph = new Graph<number>();
+
+  const n1 = 1;
+  const n2 = 2;
+  const n3 = 3;
+  const n4 = 4;
+  const n5 = 5;
+
+  graph.addNode(n1, n2, n3, n4, n5);
+
+  graph.addEdge(n2, n1);
+  graph.addEdge(n4, n3);
+  graph.addEdge(n3, n4);
+  graph.addEdge(n1, n2);
+  graph.addEdge(n1, n5);
+  graph.addEdge(n2, n3);
+  graph.addEdge(n3, n5);
+  return graph;
+}
+
+export function graph4(): Graph<number> {
+  const graph = new Graph<number>();
+
+  const n0 = 0;
+  const n1 = 1;
+  const n2 = 2;
+  const n3 = 3;
+  const n4 = 4;
+  const n5 = 5;
+  const n6 = 6;
+  const n7 = 7;
+  const n8 = 8;
+  const n9 = 9;
+  const n10 = 10;
+  const n11 = 11;
+  const n12 = 12;
+  const n13 = 13;
+  const n14 = 14;
+  const n15 = 15;
+
+  graph.addNode(
+    n0,
+    n1,
+    n2,
+    n3,
+    n4,
+    n5,
+    n6,
+    n7,
+    n8,
+    n9,
+    n10,
+    n11,
+    n12,
+    n13,
+    n14,
+    n15
+  );
+
+  graph.addEdge(n0, n1);
+  graph.addEdge(n1, n2);
+  graph.addEdge(n2, n3);
+  graph.addEdge(n2, n4);
+  graph.addEdge(n3, n8);
+  graph.addEdge(n7, n1);
+  graph.addEdge(n4, n5);
+  graph.addEdge(n5, n6);
+  graph.addEdge(n5, n7);
+  graph.addEdge(n6, n15);
+  graph.addEdge(n8, n9);
+  graph.addEdge(n9, n10);
+  graph.addEdge(n9, n11);
+  graph.addEdge(n10, n15);
+  graph.addEdge(n11, n12);
+  graph.addEdge(n12, n13);
+  graph.addEdge(n12, n14);
+  graph.addEdge(n13, n15);
+  graph.addEdge(n14, n8);
+
+  return graph;
+}


### PR DESCRIPTION
post-dominators for a given graph can be found by running dominators algorithm on the graph with reversed nodes (that is, where "from" and "to" nodes are swapped).

also updating the definition of the root that is not necessarily the first node in the graph, but rather the one that has no predecessors.